### PR TITLE
feat: QR scanner fixes, match hiding, team quick-view modal, bug fixes

### DIFF
--- a/game_config.json
+++ b/game_config.json
@@ -72,8 +72,8 @@
       "category": "subjective",
       "aggregation": "avg",
       "display_name": "Shooting Accuracy",
-      "min": 1,
-      "max": 10,
+      "min": 0,
+      "max": 100,
       "required": true
     }
     ],
@@ -122,20 +122,6 @@
       "type": "multiselect",
       "display_name": "Shooter design",
       "options": ["Hood", "Turret", "Double Shooter", "Both", "None"],
-      "required": true
-    },
-    {
-      "key": "Volume",
-      "type": "number",
-      "display_name": "How much fuel can robot hold?",
-      "min": 0,
-      "max": 100
-    },
-    {
-      "key": "Shooter",
-      "type": "multiselect",
-      "display_name": "Shooter design",
-      "options": ["Turret", "Double Shooter", "Both", "None"],
       "required": true
     },
     {

--- a/scanner/static/scanner/scanner.js
+++ b/scanner/static/scanner/scanner.js
@@ -263,16 +263,20 @@ const scanner = new QrScanner(video, result => setResult(camQrResult, result), {
         x: 0, y: 0,
         width:  v.videoWidth  || 640,
         height: v.videoHeight || 480,
+        downScaleFactor: 1,
     }),
 });
 
 scanner.start().then(() => {
     // ── Prevent library from zooming the video via inline styles ──
-    // The library sets video.style.width / height / transform when it
+    // The library sets video.style.width / height / transform / zoom when it
     // updates its overlay. We observe and immediately clear those.
     new MutationObserver(() => {
         if (video.style.transform && video.style.transform !== 'none') {
-            video.style.transform = '';
+            video.style.transform = 'none';
+        }
+        if (video.style.zoom && video.style.zoom !== '1') {
+            video.style.zoom = '1';
         }
         // Library sometimes shrinks the video to 0 when "hiding" it
         if (video.style.width  || video.style.height) {

--- a/scanner/templates/scanner/qr_scanner.html
+++ b/scanner/templates/scanner/qr_scanner.html
@@ -73,11 +73,13 @@ html.inverted .scanner-card {
     inset: 0;
     width: 100% !important;
     height: 100% !important;
-    object-fit: contain;
+    object-fit: cover;
     border-radius: inherit;
     display: block;
     transform: none !important;
+    zoom: 1 !important;
 }
+
 
 /* Canvas overlay for the yellow QR code outline */
 #qr-outline-canvas {

--- a/scanner/views.py
+++ b/scanner/views.py
@@ -51,13 +51,25 @@ def scanner(request):
                 val = data_from_post.get(key)
                 return val if val not in [None, ""] else default
 
-            # Build anchor fields — normalize quantifier from QR display labels
+            # Build anchor fields — normalize quantifier from QR display labels.
+            # Try multiple possible field names since different scouting apps vary.
             QUANTIFIER_MAP = {
-                'Quals': 'Quals', 'Qualifications': 'Quals',
-                'Playoff': 'Playoff', 'Play Off': 'Playoff', 'Playoffs': 'Playoff',
-                'Prac': 'Prac', 'Practice': 'Prac',
+                'quals': 'Quals', 'qualifications': 'Quals', 'qual': 'Quals',
+                'playoff': 'Playoff', 'play off': 'Playoff', 'playoffs': 'Playoff',
+                'elimination': 'Playoff', 'elim': 'Playoff', 'finals': 'Playoff',
+                'prac': 'Prac', 'practice': 'Prac',
             }
-            quantifier_val = QUANTIFIER_MAP.get(data_from_post.get("quantifier", ""), "Quals")
+            quantifier_raw = (
+                data_from_post.get("quantifier") or
+                data_from_post.get("matchType") or
+                data_from_post.get("match_type") or
+                data_from_post.get("type") or
+                data_from_post.get("phase") or
+                data_from_post.get("matchPhase") or
+                data_from_post.get("match_phase") or
+                ""
+            )
+            quantifier_val = QUANTIFIER_MAP.get(str(quantifier_raw).strip().lower(), "Quals")
 
             match_data_defaults = {
                 'scout_name': scout_name,

--- a/scouting_backend/urls.py
+++ b/scouting_backend/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path('strategy/picklist/submit/', strategy_views.picklist_submit, name='picklist_submit'),
     path('api/get_path_data/<int:team_number>/', strategy_views.get_path_data, name='get_path_data'),
     path('api/team_matches/<int:team_number>/', strategy_views.team_matches_detail, name='team_matches_detail'),
+    path('api/team_info/<int:team_number>/', strategy_views.team_info, name='team_info'),
     path('api/toggle_exclude_match/', strategy_views.toggle_exclude_match, name='toggle_exclude_match'),
     path("auth/", include("authenticate.urls")),
     path('admin-panel/', admin_views.admin_panel, name='admin_panel'),

--- a/strategy/templates/strategy/rankings.html
+++ b/strategy/templates/strategy/rankings.html
@@ -468,7 +468,10 @@ body.comfortable #rankings_table td {
                         </td>
                         {% for col in rankings_columns %}
                             {% if col.key == 'team_number' %}
-                                <td><a href="{% url 'team_page' team_number %}?comp={{ comp_code }}">{{ team_number }}</a></td>
+                                <td>
+                                    <a href="#" onclick="showTeamInfo({{ team_number }}, '{{ comp_code }}', '{{ selected_quantifier }}'); return false;"
+                                       style="font-weight:700;">{{ team_number }}</a>
+                                </td>
                             {% else %}
                                 <td>{{ team_stats|get_item:col.key }}</td>
                             {% endif %}
@@ -484,6 +487,50 @@ body.comfortable #rankings_table td {
         </div>
     </div>
 
+</div>
+
+<!-- Team Info Modal -->
+<div id="team-info-modal" style="display:none;position:fixed;inset:0;z-index:1001;background:rgba(0,0,0,.6);align-items:flex-start;justify-content:center;overflow-y:auto;padding:2rem 1rem;">
+    <div style="background:var(--bg-elevated);border:1px solid var(--border);border-radius:16px;max-width:820px;width:100%;padding:0;position:relative;margin:auto;">
+
+        <!-- Header -->
+        <div id="ti-header" style="display:flex;align-items:center;gap:1rem;padding:1.25rem 1.5rem;border-bottom:1px solid var(--border);">
+            <img id="ti-logo" src="" alt="" style="width:56px;height:56px;object-fit:contain;border-radius:8px;background:#fff;padding:4px;display:none;">
+            <div style="flex:1;">
+                <div style="font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.07em;color:var(--muted-text);">Team</div>
+                <div id="ti-team-number" style="font-size:1.8rem;font-weight:900;color:var(--accent);line-height:1.1;"></div>
+            </div>
+            <a id="ti-full-link" href="#" style="font-size:0.8rem;font-weight:700;color:var(--accent);text-decoration:none;padding:6px 14px;border:1px solid var(--accent);border-radius:8px;white-space:nowrap;">Full Page ↗</a>
+            <button onclick="document.getElementById('team-info-modal').style.display='none'"
+                    style="background:none;border:none;color:var(--muted-text);font-size:1.5rem;cursor:pointer;line-height:1;padding:4px 8px;">&times;</button>
+        </div>
+
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:0;border-bottom:1px solid var(--border);">
+            <!-- Pit data -->
+            <div style="padding:1.25rem 1.5rem;border-right:1px solid var(--border);">
+                <div style="font-size:0.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--accent);margin-bottom:.75rem;">Pit Scouting</div>
+                <div id="ti-pit-body"></div>
+            </div>
+            <!-- Robot picture -->
+            <div style="padding:1.25rem 1.5rem;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;gap:.75rem;">
+                <div style="font-size:0.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--accent);align-self:flex-start;">Robot</div>
+                <img id="ti-robot-pic" src="" alt="Robot" style="max-width:100%;border-radius:10px;border:1px solid var(--border);display:none;">
+                <span id="ti-no-pic" style="font-size:0.85rem;color:var(--muted-text);display:none;">No robot picture uploaded.</span>
+            </div>
+        </div>
+
+        <!-- Match history -->
+        <div style="padding:1.25rem 1.5rem;">
+            <div style="font-size:0.72rem;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--accent);margin-bottom:.75rem;">Match History</div>
+            <div style="overflow-x:auto;">
+                <table id="ti-match-table" style="width:100%;border-collapse:collapse;font-size:13px;">
+                    <thead><tr id="ti-match-head" style="border-bottom:2px solid var(--border);"></tr></thead>
+                    <tbody id="ti-match-body"></tbody>
+                </table>
+            </div>
+        </div>
+
+    </div>
 </div>
 
 <!-- Match Detail Modal -->
@@ -513,6 +560,136 @@ body.comfortable #rankings_table td {
 </script>
 
 <script>
+function showTeamInfo(teamNum, comp, quantifier) {
+    var modal = document.getElementById('team-info-modal');
+    modal.style.display = 'flex';
+
+    // Reset UI
+    document.getElementById('ti-team-number').textContent = teamNum;
+    document.getElementById('ti-full-link').href = '/teams/' + teamNum + '/?comp=' + comp;
+    document.getElementById('ti-logo').style.display = 'none';
+    document.getElementById('ti-robot-pic').style.display = 'none';
+    document.getElementById('ti-no-pic').style.display = 'none';
+    document.getElementById('ti-pit-body').innerHTML = '<span style="font-size:0.85rem;color:var(--muted-text);">Loading…</span>';
+    document.getElementById('ti-match-head').innerHTML = '';
+    document.getElementById('ti-match-body').innerHTML = '';
+
+    fetch('/api/team_info/' + teamNum + '/?comp=' + comp + '&quantifier=' + quantifier)
+        .then(function(r) { return r.json(); })
+        .then(function(d) {
+            // Logo
+            if (d.logo_url) {
+                var logo = document.getElementById('ti-logo');
+                logo.src = d.logo_url;
+                logo.style.display = 'block';
+            }
+
+            // Robot picture
+            if (d.robot_picture) {
+                var pic = document.getElementById('ti-robot-pic');
+                pic.src = d.robot_picture;
+                pic.style.display = 'block';
+            } else {
+                document.getElementById('ti-no-pic').style.display = 'block';
+            }
+
+            // Pit data
+            var pitBody = document.getElementById('ti-pit-body');
+            if (d.pit_scout_status && d.pit_data && Object.keys(d.pit_data).length) {
+                var dl = document.createElement('dl');
+                dl.style.cssText = 'margin:0;display:grid;grid-template-columns:auto 1fr;gap:2px 12px;';
+                Object.entries(d.pit_data).forEach(function(entry) {
+                    var key = entry[0], val = entry[1];
+                    if (val === null || val === '' || (Array.isArray(val) && !val.length)) return;
+                    var label = key.replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+                    var display = Array.isArray(val) ? val.join(', ') : String(val);
+
+                    var dt = document.createElement('dt');
+                    dt.style.cssText = 'font-size:0.78rem;font-weight:700;color:var(--muted-text);padding:3px 0;white-space:nowrap;';
+                    dt.textContent = label;
+
+                    var dd = document.createElement('dd');
+                    dd.style.cssText = 'font-size:0.82rem;font-weight:500;color:var(--text);margin:0;padding:3px 0;';
+                    dd.textContent = display;
+
+                    dl.appendChild(dt);
+                    dl.appendChild(dd);
+                });
+                pitBody.innerHTML = '';
+                pitBody.appendChild(dl);
+            } else {
+                pitBody.innerHTML = '<span style="font-size:0.85rem;color:var(--muted-text);">No pit data collected yet.</span>';
+            }
+
+            // Match history
+            var head = document.getElementById('ti-match-head');
+            var body = document.getElementById('ti-match-body');
+
+            if (!d.matches || !d.matches.length) {
+                body.innerHTML = '<tr><td colspan="99" style="padding:12px;color:var(--muted-text);text-align:center;">No matches found.</td></tr>';
+                return;
+            }
+
+            // Build header
+            var metricKeys = (d.metrics || []).map(function(m) { return m.key; });
+            var metricLabels = {};
+            (d.metrics || []).forEach(function(m) { metricLabels[m.key] = m.display_name; });
+
+            var headers = ['Match', 'Leave', 'Scout', 'Driver', 'Defense'].concat(
+                (d.metrics || []).map(function(m) { return m.display_name; }),
+                ['Notes']
+            );
+            headers.forEach(function(h) {
+                var th = document.createElement('th');
+                th.textContent = h;
+                th.style.cssText = 'padding:5px 8px;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:.05em;color:var(--accent);text-align:center;white-space:nowrap;';
+                head.appendChild(th);
+            });
+
+            d.matches.forEach(function(m) {
+                var tr = document.createElement('tr');
+                if (m.excluded) {
+                    tr.style.cssText = 'opacity:0.4;text-decoration:line-through;';
+                }
+                tr.style.borderBottom = '1px solid var(--border)';
+
+                function cell(text, opts) {
+                    var td = document.createElement('td');
+                    td.textContent = text != null ? text : '—';
+                    td.style.cssText = 'padding:4px 8px;text-align:center;color:var(--text);font-size:0.82rem;' + (opts || '');
+                    return td;
+                }
+
+                var flags = (m.flags || []).join(' ');
+                var matchLabel = m.match_number + (flags ? ' ⚠' : '');
+                var matchCell = cell(matchLabel);
+                if (flags) matchCell.title = flags;
+                tr.appendChild(matchCell);
+
+                tr.appendChild(cell(m.autoLeave || 0));
+                tr.appendChild(cell(m.scout_name, 'white-space:nowrap;'));
+                tr.appendChild(cell(m.driverRanking || 0));
+                tr.appendChild(cell(m.defenseRanking || 0));
+
+                metricKeys.forEach(function(k) {
+                    tr.appendChild(cell(m.data && m.data[k] != null ? m.data[k] : '—'));
+                });
+
+                tr.appendChild(cell(m.comment || '', 'white-space:nowrap;max-width:200px;overflow:hidden;text-overflow:ellipsis;text-align:left;'));
+
+                body.appendChild(tr);
+            });
+        })
+        .catch(function() {
+            document.getElementById('ti-pit-body').innerHTML = '<span style="color:#ef4444;font-size:0.85rem;">Failed to load team data.</span>';
+        });
+}
+
+// Close team-info modal when clicking the backdrop
+document.getElementById('team-info-modal').addEventListener('click', function(e) {
+    if (e.target === this) this.style.display = 'none';
+});
+
 function showMatchDetail(teamNum, comp, quantifier) {
     var modal = document.getElementById('match-modal');
     document.getElementById('modal-title').textContent = 'Team ' + teamNum + ' — Individual Matches';

--- a/strategy/views.py
+++ b/strategy/views.py
@@ -16,7 +16,7 @@ from teams import models
 from helpers import login_required
 from django.shortcuts import render, redirect
 from strategy.models import PickList_Data
-from teams.models import Team_Match_Data
+from teams.models import Team_Match_Data, Teams
 from utils import config_loader
 
 _SAFE_COMP_CODE = re.compile(r'^[A-Za-z0-9_\-]{1,20}$')
@@ -515,3 +515,50 @@ def get_path_data(request, team_number):
         
     except Exception:
         return JsonResponse({'error': 'An unexpected error occurred'}, status=500)
+
+
+@login_required
+def team_info(request, team_number):
+    """Return pit scouting info + full match history for a team — used by the rankings quick-view modal."""
+    comp_code = request.GET.get('comp')
+    quantifier = request.GET.get('quantifier', 'Quals')
+    if not comp_code:
+        return JsonResponse({'error': 'comp required'}, status=400)
+
+    team = Teams.objects.filter(team_number=team_number, event=comp_code).first()
+    matches = Team_Match_Data.objects.filter(
+        team_number=team_number, event=comp_code, quantifier=quantifier
+    ).order_by('match_number')
+
+    excluded = set(request.session.get('excluded_match_ids', []))
+    config = config_loader.get_config()
+    metrics = config.get('metrics', [])
+
+    match_list = []
+    for m in matches:
+        flags = []
+        if m.is_broken:   flags.append('Broken')
+        if m.is_disabled: flags.append('Disabled')
+        if m.is_tipped:   flags.append('Tipped')
+        match_list.append({
+            'id': m.id,
+            'match_number': m.match_number,
+            'scout_name': m.scout_name,
+            'autoLeave': m.autoLeave,
+            'driverRanking': m.driverRanking,
+            'defenseRanking': m.defenseRanking,
+            'comment': m.comment,
+            'flags': flags,
+            'data': m.data,
+            'excluded': m.id in excluded,
+        })
+
+    return JsonResponse({
+        'team_number': team_number,
+        'logo_url': team.logo_url if team else None,
+        'robot_picture': str(team.robot_picture) if team and team.robot_picture else None,
+        'pit_scout_status': team.pit_scout_status if team else False,
+        'pit_data': team.pit_data if team else {},
+        'metrics': [{'key': m['key'], 'display_name': m['display_name']} for m in metrics],
+        'matches': match_list,
+    })

--- a/teams/templates/teams/pit_scouting.html
+++ b/teams/templates/teams/pit_scouting.html
@@ -23,6 +23,17 @@
     </div>
 </div>
 
+{% if field_errors %}
+<div style="background:color-mix(in srgb,var(--accent) 10%,var(--bg-elevated));border:1px solid var(--accent);border-radius:12px;padding:1rem 1.25rem;margin-bottom:1rem;font-size:0.88rem;color:var(--accent);font-weight:600;">
+    Please fix the errors below before submitting.
+    {% if field_errors._general %}
+    <ul style="margin:0.5rem 0 0;padding-left:1.25rem;">
+        {% for err in field_errors._general %}<li>{{ err }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+</div>
+{% endif %}
+
 <form method="POST" enctype="multipart/form-data" novalidate id="pit-form">
     {% csrf_token %}
 
@@ -107,7 +118,13 @@
             </div>
         {% endif %}
 
-        <div class="invalid-feedback" id="error-{{ q.key }}"></div>
+        {% if field_errors %}
+            {% with err=field_errors|get_item:q.key %}
+                {% if err %}<div class="invalid-feedback" id="error-{{ q.key }}" style="display:block;">{{ err }}</div>{% endif %}
+            {% endwith %}
+        {% else %}
+            <div class="invalid-feedback" id="error-{{ q.key }}"></div>
+        {% endif %}
     </div>
     {% endfor %}
 
@@ -913,6 +930,14 @@ html.inverted .form-group:hover {
     /* Apply i18n on load */
     if (window.applyTranslations) {
         window.applyTranslations(localStorage.getItem('lang') || 'en');
+    }
+
+    /* ---- Mobile camera: open rear camera directly on phones ---- */
+    var robotFileInput = document.getElementById('robot-file-input');
+    if (robotFileInput && /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
+        robotFileInput.setAttribute('capture', 'environment');
+        var fileDropLabel = document.getElementById('file-label');
+        if (fileDropLabel) fileDropLabel.textContent = 'Tap to take a photo';
     }
 })();
 </script>

--- a/teams/templates/teams/team_page.html
+++ b/teams/templates/teams/team_page.html
@@ -104,14 +104,14 @@
         </thead>
         <tbody>
             {% for match in all_team_match_data %}
-            <tr>
+            <tr data-match-id="{{ match.id }}">
                 <td>{{ match.match_number }} ({{ match.quantifier }})</td>
                 <td>{{ match.autoLeave|default:"0" }}</td>
-                
+
                 {% for metric in config_metrics %}
                     <td>{{ match.data|get_item:metric.key|default:"0" }}</td>
                 {% endfor %}
-                
+
                 <td>{{ match.scout_name }}</td>
                 <td>{{ match.driverRanking|default:"0" }}</td>
                 <td>{{ match.defenseRanking|default:"0" }}</td>
@@ -120,6 +120,11 @@
                     {% if match.is_disabled %}<span class="badge bg-warning">Disabled</span>{% endif %}
                     {% if match.is_tipped %}<span class="badge bg-info">Tipped</span>{% endif %}
                     {{ match.comment }}
+                </td>
+                <td>
+                    <button class="hide-match-btn" data-match-id="{{ match.id }}" title="Hide match from rankings averages">
+                        Hide
+                    </button>
                 </td>
                 {% plugin_hook 'team_page_match_row' %}
             </tr>
@@ -407,6 +412,41 @@
     width: 100%;
 }
 
+/* =========================
+   Hidden match rows
+   ========================= */
+tr.match-hidden td {
+    color: var(--muted-text) !important;
+    text-decoration: line-through;
+    opacity: 0.5;
+}
+
+tr.match-hidden .hide-match-btn {
+    background: color-mix(in srgb, #22c55e 15%, var(--bg-elevated));
+    color: #16a34a;
+    border-color: color-mix(in srgb, #22c55e 35%, var(--border));
+}
+
+/* =========================
+   Hide match button
+   ========================= */
+.hide-match-btn {
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 6px;
+    border: 1px solid color-mix(in srgb, #ef4444 35%, var(--border));
+    background: color-mix(in srgb, #ef4444 10%, var(--bg-elevated));
+    color: #ef4444;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    white-space: nowrap;
+}
+
+.hide-match-btn:hover {
+    background: color-mix(in srgb, #ef4444 20%, var(--bg-elevated));
+}
+
 /* Match history row entry */
 #match_data tbody tr {
     animation: rowSlideIn 0.28s var(--ease-out, cubic-bezier(0.22,1,0.36,1)) both;
@@ -438,6 +478,68 @@ function confirmClearPitData() {
     var rows = document.querySelectorAll('#match_data tbody tr');
     rows.forEach(function (row, i) {
         row.style.animationDelay = Math.min(i * 16, 260) + 'ms';
+    });
+})();
+
+/* ── Match hide/unhide ────────────────────────────────────────── */
+(function () {
+    // Excluded match IDs from server session
+    var excludedIds = new Set({{ excluded_match_ids_json|safe }});
+
+    function getCsrf() {
+        var m = document.cookie.match(/csrftoken=([^;]+)/);
+        return m ? m[1] : '';
+    }
+
+    function applyHiddenState(row, hidden) {
+        if (hidden) {
+            row.classList.add('match-hidden');
+            row.querySelector('.hide-match-btn').textContent = 'Show';
+            row.querySelector('.hide-match-btn').title = 'Re-include match in rankings averages';
+        } else {
+            row.classList.remove('match-hidden');
+            row.querySelector('.hide-match-btn').textContent = 'Hide';
+            row.querySelector('.hide-match-btn').title = 'Hide match from rankings averages';
+        }
+    }
+
+    // Apply initial state from session
+    document.querySelectorAll('#match_data tbody tr[data-match-id]').forEach(function (row) {
+        var id = parseInt(row.dataset.matchId, 10);
+        if (excludedIds.has(id)) {
+            applyHiddenState(row, true);
+        }
+    });
+
+    // Toggle on button click
+    document.querySelectorAll('.hide-match-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var matchId = parseInt(btn.dataset.matchId, 10);
+            var row = btn.closest('tr');
+
+            fetch('/api/toggle_exclude_match/', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCsrf(),
+                },
+                body: JSON.stringify({ match_id: matchId }),
+            })
+            .then(function (r) { return r.json(); })
+            .then(function (res) {
+                var nowExcluded = res.status === 'excluded';
+                applyHiddenState(row, nowExcluded);
+                if (nowExcluded) {
+                    excludedIds.add(matchId);
+                } else {
+                    excludedIds.delete(matchId);
+                }
+            })
+            .catch(function () {
+                alert('Failed to update match visibility. Please try again.');
+            });
+        });
     });
 })();
 </script>

--- a/teams/views.py
+++ b/teams/views.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from PIL import Image
@@ -64,17 +65,19 @@ def display_teams(request):
 def team_page(request, team_number):
     comp_code = request.GET.get('comp')
     config = config_loader.get_config()
-    
+    excluded_ids = set(request.session.get('excluded_match_ids', []))
+
     context = {
         'team_number': team_number,
         'comp_code': comp_code,
         'config_metrics': config.get('metrics', []),
+        'excluded_match_ids_json': json.dumps(list(excluded_ids)),
     }
 
     if comp_code:
         team, created = Teams.objects.get_or_create(team_number=team_number, event=comp_code)
         all_team_match_data = Team_Match_Data.objects.filter(
-            team_number=team_number, 
+            team_number=team_number,
             event=comp_code
         ).order_by('-match_number')
 
@@ -82,7 +85,7 @@ def team_page(request, team_number):
             'team': team,
             'all_team_match_data': all_team_match_data,
         })
-        
+
     return render(request, 'teams/team_page.html', context)
 
 
@@ -192,6 +195,8 @@ def pit_scouting(request, team_number):
                 'questions': config.get('pit_questions', []),
                 'existing_data': pit_payload,
                 'field_errors': field_errors,
+                'comp_code': comp_code,
+                'has_robot_picture': bool(team.robot_picture),
             })
         
         # Save
@@ -250,8 +255,11 @@ def human_player_submit(request, team_number):
                                               match_number=form.cleaned_data.get('match_number'),
                                               human_player_comment=form.cleaned_data.get('human_player_comment'))
 
-            return redirect("team_page", team_number=team_number)
+            redirect_url = f'/teams/{team_number}/'
+            if comp_code:
+                redirect_url += f'?comp={comp_code}'
+            return redirect(redirect_url)
     else:
         form = NewHumanScoutingData()
-    return render(request, "teams/human_player_scout.html", {'form': form, 'team_number': team_number})
+    return render(request, "teams/human_player_scout.html", {'form': form, 'team_number': team_number, 'comp_code': comp_code})
 


### PR DESCRIPTION
## Summary

### QR Scanner
- Prevent camera zoom on scan: full-frame scan region (`downScaleFactor: 1`), MutationObserver guards `transform`/`zoom` CSS, hardware zoom locked to 1×
- Remove black letterbox bars (`object-fit: cover`)
- Playoff quantifier detection now tries 7 field names (`quantifier`, `matchType`, `match_type`, `type`, `phase`, `matchPhase`, `match_phase`) and is case-insensitive — prevents playoff matches silently saving as Quals

### Team page — Match hiding
- Hide/Show button on each match row; grays out + strikes through the row
- Calls `/api/toggle_exclude_match/` so rankings automatically exclude hidden matches from averages
- Hidden state restored from session on page load

### Rankings — Team quick-view modal
- Clicking a team number opens an inline modal instead of navigating away
- Modal shows: team logo, robot picture, full pit scouting data, and match history with all metrics
- Excluded matches shown grayed out with strikethrough
- "Full Page ↗" link to the complete team page
- New API: `GET /api/team_info/<team_number>/?comp=&quantifier=`

### Pit scouting
- On mobile, robot picture input opens rear camera directly (`capture="environment"`)
- Server-side `field_errors` now displayed in template (were silently ignored)
- General error banner added at top of form on validation failure

### game_config.json
- `shootingAccuracy` range: `min 1 → 0`, `max 10 → 100`
- Removed duplicate `Volume` and `Shooter` pit question entries

### Bug fixes
- `pit_scouting` error-path render was missing `comp_code` and `has_robot_picture`
- `human_player_submit` redirect now preserves `comp_code` query param

## Test plan
- [ ] Scan Quals QR → saved as Quals; scan Playoff QR → saved as Playoff in rankings
- [ ] QR scanner: no zoom/reflow on scan, no black bars
- [ ] Team page: Hide a match → grayed/strikethrough; rankings average updates
- [ ] Rankings: click a team number → modal opens with pit data, robot pic, match history
- [ ] Rankings: "Full Page ↗" navigates to team page
- [ ] Pit scouting on mobile: tapping photo zone opens camera
- [ ] Pit scouting: validation errors shown inline and in banner
- [ ] `shootingAccuracy` accepts 0–100
